### PR TITLE
Fixing 'Appears to be a git repo or submodule' bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,9 @@
 # Created by .ignore support plugin (hsz.mobi)
 examples
+
+# 'Appears to be a git repo or submodule' error fix
+.git
+
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fusebox-pug-plugin",
+  "name": "fusebox-pug-plugin-fixed",
   "version": "2.0.1",
   "description": "Import pug files with fusebox allowing to use ~ to import from root and node: to import from node_modules",
   "main": "index.js",
@@ -10,7 +10,7 @@
   "module": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/davinchi-finsi/fusebox-pug-plugin.git"
+    "url": "https://github.com/diwiny/fusebox-pug-plugin.git"
   },
   "publishConfig": {
     "access": "public"
@@ -25,10 +25,10 @@
     "pug"
   ],
   "bugs": {
-    "url": "https://github.com/davinchi-finsi/fusebox-pug-plugin/issues"
+    "url": "https://github.com/diwiny/fusebox-pug-plugin/issues"
   },
   "license": "MIT",
-  "homepage": "https://github.com/davinchi-finsi/fusebox-pug-plugin",
+  "homepage": "https://github.com/diwiny/fusebox-pug-plugin",
   "dependencies": {
     "@types/pug": "^2.0.4",
     "extend": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusebox-pug-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Import pug files with fusebox allowing to use ~ to import from root and node: to import from node_modules",
   "main": "index.js",
   "scripts": {
@@ -16,8 +16,8 @@
     "access": "public"
   },
   "author": {
-    "name": "Davinchi",
-    "url": "www.davinchi.es"
+    "name": "Lajos Kovacs",
+    "url": "diwiny.hu"
   },
   "keywords": [
     "fusebox",


### PR DESCRIPTION
We are actively using this lib, but always got the problem: 'fusebox-pug-plugin: Appears to be a git repo or submodule'.
This should fix the problem.